### PR TITLE
Refactor IPAQ module for modularity

### DIFF
--- a/lib/src/ipaq/model/items.dart
+++ b/lib/src/ipaq/model/items.dart
@@ -1,31 +1,31 @@
-import 'package:research_package/research_package.dart';
 import 'package:mdigits/src/ipaq/view/duration_answer_format.dart';
+import 'package:research_package/research_package.dart';
 
-final RPQuestionStep ipaq_1 = RPQuestionStep(
-  identifier: "ipaq_vigorous",
-  title:
-      "¿Cuánto tiempo dedicaste hoy a realizar actividades físicas vigorosas?",
-  answerFormat: DurationAnswerFormat(),
-);
+class IPAQQuestion {
+  final String identifier;
+  final String title;
 
-final RPQuestionStep ipaq_2 = RPQuestionStep(
-  identifier: "ipaq_moderate",
-  title:
-      "¿Cuánto tiempo dedicaste hoy a realizar actividades físicas moderadas?",
-  answerFormat: DurationAnswerFormat(),
-);
+  const IPAQQuestion(this.identifier, this.title);
+}
 
-final RPQuestionStep ipaq_3 = RPQuestionStep(
-  identifier: "ipaq_walk",
-  title: "¿Cuánto tiempo dedicaste hoy a caminar?",
-  answerFormat: DurationAnswerFormat(),
-);
-
-final RPQuestionStep ipaq_4 = RPQuestionStep(
-  identifier: "ipaq_seated",
-  title: "¿Cuánto tiempo estuviste hoy sentado?",
-  answerFormat: DurationAnswerFormat(),
-);
+const List<IPAQQuestion> _questions = [
+  IPAQQuestion(
+    'ipaq_vigorous',
+    '¿Cuánto tiempo dedicaste hoy a realizar actividades físicas vigorosas?',
+  ),
+  IPAQQuestion(
+    'ipaq_moderate',
+    '¿Cuánto tiempo dedicaste hoy a realizar actividades físicas moderadas?',
+  ),
+  IPAQQuestion(
+    'ipaq_walk',
+    '¿Cuánto tiempo dedicaste hoy a caminar?',
+  ),
+  IPAQQuestion(
+    'ipaq_seated',
+    '¿Cuánto tiempo estuviste hoy sentado?',
+  ),
+];
 
 final List<RPStep> ipaqSteps = [
   RPInstructionStep(
@@ -34,8 +34,12 @@ final List<RPStep> ipaqSteps = [
     detailText:
         'A continuación responderás algunas preguntas sobre la clase de actividad física que realizaste hoy.\n\nPor favor, responde a cada pregunta aún si no te consideras una persona activa.\n\nPor favor, piensa en aquellas actividades que haces como parte del trabajo, en el jardín y en la casa, para ir de un sitio a otro, y en tu tiempo libre de descanso, ejercicio o deporte.',
   ),
-  ipaq_1,
-  ipaq_2,
-  ipaq_3,
-  ipaq_4,
+  ..._questions.map(
+    (q) => RPQuestionStep(
+      identifier: q.identifier,
+      title: q.title,
+      answerFormat: DurationAnswerFormat(),
+    ),
+  ),
 ];
+

--- a/lib/src/ipaq/view/custom_answer_result.dart
+++ b/lib/src/ipaq/view/custom_answer_result.dart
@@ -1,7 +1,7 @@
 import 'package:research_package/model.dart';
 
-class CustomAnswerResult extends RPResult {
-  final dynamic answer;
+class CustomAnswerResult<T> extends RPResult {
+  final T? answer;
 
   CustomAnswerResult({
     required String identifier,

--- a/lib/src/ipaq/view/custom_task_widget.dart
+++ b/lib/src/ipaq/view/custom_task_widget.dart
@@ -22,12 +22,12 @@ class CustomTaskWidget extends StatefulWidget {
 class _CustomTaskWidgetState extends State<CustomTaskWidget> {
   int _currentStepIndex = 0;
   final RPTaskResult _taskResult = RPTaskResult(identifier: 'custom_task');
-  dynamic _currentAnswer;
+  Object? _currentAnswer;
 
   void _nextStep() {
     final currentStep = widget.task.steps[_currentStepIndex];
 
-    final stepResult = CustomAnswerResult(
+    final stepResult = CustomAnswerResult<Object?>(
       identifier: currentStep.identifier,
       answer: _currentAnswer,
     );
@@ -52,63 +52,46 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
     }
   }
 
+  Widget _buildStepWidget(RPStep step) {
+    if (step is RPInstructionStep) {
+      return _InstructionStep(step: step);
+    } else if (step is RPQuestionStep &&
+        step.answerFormat is DurationAnswerFormat) {
+      return _DurationQuestionStep(
+        step: step,
+        onChanged: (val) => setState(() => _currentAnswer = val),
+      );
+    } else if (step is RPQuestionStep &&
+        step.answerFormat is wheel.WheelAnswerFormat) {
+      return _WheelQuestionStep(
+        step: step,
+        onChanged: (val) => setState(() => _currentAnswer = val),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
   @override
   Widget build(BuildContext context) {
     final step = widget.task.steps[_currentStepIndex];
 
     return Scaffold(
       appBar: AppBar(
-          title: Text(
-            step is RPInstructionStep
-                ? step.title
-                : 'Pregunta $_currentStepIndex',
-            style: const TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
-            textAlign: TextAlign.center,
-          ),
-          backgroundColor: const Color.fromARGB(255, 217, 217, 217)),
+        title: Text(
+          step is RPInstructionStep
+              ? step.title
+              : 'Pregunta $_currentStepIndex',
+          style: const TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
+          textAlign: TextAlign.center,
+        ),
+        backgroundColor: const Color.fromARGB(255, 217, 217, 217),
+      ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            if (step is RPInstructionStep) ...[
-              Text(
-                step.detailText ?? '',
-                style: const TextStyle(fontSize: 25),
-                textAlign: TextAlign.left,
-              ),
-            ] else if (step is RPQuestionStep &&
-                step.answerFormat is DurationAnswerFormat) ...[
-              Text(
-                step.title,
-                style:
-                    const TextStyle(fontSize: 25, fontWeight: FontWeight.w500),
-                textAlign: TextAlign.left,
-              ),
-              CustomRPUIDateTimeQuestionBody(
-                key: ValueKey(step.identifier),
-                answerFormat: step.answerFormat as DurationAnswerFormat,
-                onResultChange: (val) {
-                  setState(() => _currentAnswer = val);
-                },
-              ),
-            ] else if (step is RPQuestionStep &&
-                step.answerFormat is wheel.WheelAnswerFormat) ...[
-              Text(
-                step.title,
-                style:
-                    const TextStyle(fontSize: 25, fontWeight: FontWeight.w500),
-                textAlign: TextAlign.left,
-              ),
-              wheel.WheelQuestionBody(
-                answerFormat: step.answerFormat as wheel.WheelAnswerFormat,
-                onResultChange: (val) {
-                  setState(() {
-                    _currentAnswer = val;
-                  });
-                },
-              ),
-            ],
+            _buildStepWidget(step),
             Row(
               children: [
                 Expanded(
@@ -156,6 +139,77 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _InstructionStep extends StatelessWidget {
+  final RPInstructionStep step;
+  const _InstructionStep({required this.step});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      step.detailText ?? '',
+      style: const TextStyle(fontSize: 25),
+      textAlign: TextAlign.left,
+    );
+  }
+}
+
+class _DurationQuestionStep extends StatelessWidget {
+  final RPQuestionStep step;
+  final ValueChanged<Object?> onChanged;
+
+  const _DurationQuestionStep({
+    required this.step,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          step.title,
+          style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w500),
+          textAlign: TextAlign.left,
+        ),
+        CustomRPUIDateTimeQuestionBody(
+          key: ValueKey(step.identifier),
+          answerFormat: step.answerFormat as DurationAnswerFormat,
+          onResultChange: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _WheelQuestionStep extends StatelessWidget {
+  final RPQuestionStep step;
+  final ValueChanged<Object?> onChanged;
+
+  const _WheelQuestionStep({
+    required this.step,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          step.title,
+          style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w500),
+          textAlign: TextAlign.left,
+        ),
+        wheel.WheelQuestionBody(
+          answerFormat: step.answerFormat as wheel.WheelAnswerFormat,
+          onResultChange: onChanged,
+        ),
+      ],
     );
   }
 }

--- a/lib/src/ipaq/view/ipaq_page.dart
+++ b/lib/src/ipaq/view/ipaq_page.dart
@@ -1,17 +1,20 @@
 import 'package:flutter/material.dart';
-import '../viewmodel/ipaq_viewmodel.dart';
+import 'package:research_package/model.dart';
+
 import '../view/custom_task_widget.dart';
+import '../viewmodel/ipaq_viewmodel.dart';
 
 class IPAQPage extends StatelessWidget {
-  final IPAQViewModel viewModel = IPAQViewModel();
+  final IPAQViewModel viewModel;
+  final void Function(RPTaskResult) onSubmit;
 
-  IPAQPage({super.key});
+  const IPAQPage({super.key, required this.viewModel, required this.onSubmit});
 
   @override
   Widget build(BuildContext context) {
     return CustomTaskWidget(
       task: viewModel.task,
-      onSubmit: (result) {},
+      onSubmit: onSubmit,
     );
   }
 }

--- a/lib/src/ipaq/viewmodel/ipaq_viewmodel.dart
+++ b/lib/src/ipaq/viewmodel/ipaq_viewmodel.dart
@@ -1,9 +1,12 @@
-import 'package:research_package/research_package.dart';
 import 'package:mdigits/src/ipaq/model/items.dart';
+import 'package:research_package/research_package.dart';
 
 class IPAQViewModel {
-  RPOrderedTask get task => RPOrderedTask(
-        identifier: 'ipaq_task',
-        steps: ipaqSteps,
-      );
+  final RPOrderedTask task;
+
+  IPAQViewModel()
+      : task = RPOrderedTask(
+          identifier: 'ipaq_task',
+          steps: ipaqSteps,
+        );
 }


### PR DESCRIPTION
## Summary
- Centralize IPAQ questionnaire configuration and map data into steps
- Cache task in `IPAQViewModel` and allow view-model injection with submit callback
- Replace dynamic answer handling with typed results and step-specific widgets

## Testing
- `flutter format lib/src/ipaq/model/items.dart lib/src/ipaq/viewmodel/ipaq_viewmodel.dart lib/src/ipaq/view/ipaq_page.dart lib/src/ipaq/view/custom_answer_result.dart lib/src/ipaq/view/custom_task_widget.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6895073196b08331a5307a725a1592e9